### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,8 @@
 # yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
 
 name: build
+permissions:
+  contents: read
 on:
   workflow_dispatch:
   push:

--- a/.github/workflows/publish-nuget.yml
+++ b/.github/workflows/publish-nuget.yml
@@ -26,6 +26,8 @@ jobs:
   package:
     name: Build NuGet Package
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
     steps:
     - uses: actions/checkout@v4.2.2
       with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,6 +1,8 @@
 # yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
 
 name: publish
+permissions:
+  contents: read
 on:
     workflow_dispatch:
       inputs:


### PR DESCRIPTION
Potential fix for [https://github.com/NF-Software-Inc/zkteco-attendance-api/security/code-scanning/1](https://github.com/NF-Software-Inc/zkteco-attendance-api/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the workflow level to explicitly define the least privileges required. Since the workflow only performs read operations (e.g., checking out the repository and restoring dependencies), we will set `contents: read`. This ensures that the `GITHUB_TOKEN` has only the permissions necessary for the workflow to function.

The `permissions` block will be added at the root level of the workflow, just below the `name` field, so it applies to all jobs in the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
